### PR TITLE
LUGG-654 - Add read more settings

### DIFF
--- a/luggage_events.info
+++ b/luggage_events.info
@@ -51,6 +51,7 @@ features[variable][] = node_options_event
 features[variable][] = node_preview_event
 features[variable][] = node_submitted_event
 features[variable][] = publishcontent_event
+features[variable][] = read_more_event_view_modes
 features[views_view][] = events
 features_exclude[dependencies][luggage_events_video] = luggage_events_video
 features_exclude[field_base][field_event_transcript] = field_event_transcript

--- a/luggage_events.strongarm.inc
+++ b/luggage_events.strongarm.inc
@@ -116,5 +116,21 @@ function luggage_events_strongarm() {
   $strongarm->value = 1;
   $export['publishcontent_event'] = $strongarm;
 
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'read_more_event_view_modes';
+  $strongarm->value = array(
+    'teaser' => 'teaser',
+    'search_result' => 'search_result',
+    'full' => 0,
+    'rss' => 0,
+    'search_index' => 0,
+    'diff_standard' => 0,
+    'token' => 0,
+    'revision' => 0,
+  );
+  $export['read_more_event_view_modes'] = $strongarm;
+
   return $export;
 }


### PR DESCRIPTION
Added strongarm settings for the read more module.

To test:
Pull down these changes on a site with an up-to-date version of the read more module
Run "drush fra -y" on the site you're using for testing
Go to Administration > Configuration > Content Authoring > Read More link
Scroll down to the "Content Types" section of configuration
Verify that teaser and search result highlighting input boxes are both checked for event
