### PR TITLE
LUGG-900 Filter Upcoming Events page and block by end date 1 hour granularity

### DIFF
--- a/luggage_events.views_default.inc
+++ b/luggage_events.views_default.inc
@@ -339,10 +339,11 @@ function luggage_events_views_default_views() {
   $handler->display->display_options['filters']['date_filter']['table'] = 'node';
   $handler->display->display_options['filters']['date_filter']['field'] = 'date_filter';
   $handler->display->display_options['filters']['date_filter']['operator'] = '>=';
+  $handler->display->display_options['filters']['date_filter']['granularity'] = 'hour';
   $handler->display->display_options['filters']['date_filter']['default_date'] = 'now';
   $handler->display->display_options['filters']['date_filter']['add_delta'] = 'yes';
   $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
-    'field_data_field_event_when.field_event_when_value' => 'field_data_field_event_when.field_event_when_value',
+    'field_data_field_event_when.field_event_when_value2' => 'field_data_field_event_when.field_event_when_value2',
   );
   $handler->display->display_options['block_description'] = 'Upcoming Events';
 
@@ -421,9 +422,10 @@ function luggage_events_views_default_views() {
   $handler->display->display_options['filters']['date_filter']['table'] = 'node';
   $handler->display->display_options['filters']['date_filter']['field'] = 'date_filter';
   $handler->display->display_options['filters']['date_filter']['operator'] = '>=';
+  $handler->display->display_options['filters']['date_filter']['granularity'] = 'hour';
   $handler->display->display_options['filters']['date_filter']['default_date'] = 'now';
   $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
-    'field_data_field_event_when.field_event_when_value' => 'field_data_field_event_when.field_event_when_value',
+    'field_data_field_event_when.field_event_when_value2' => 'field_data_field_event_when.field_event_when_value2',
   );
   /* Filter criterion: Content: Has taxonomy term */
   $handler->display->display_options['filters']['tid']['id'] = 'tid';


### PR DESCRIPTION
On events that last more than a day, the event would disappear from the Upcoming events page and block. It looks like what was delivered with luggage was that it was based on start date. The granularity was set to Day, so events never really disappeared prematurely unless the event ran in multiple days. 

This PR changes the filter to look at the end date/time instead of the start and also set the granularity to an hour.