### PR TITLE
LUGG-1019 Added date_all_day module dependency and checkbox

### DIFF
--- a/luggage_events.features.field_instance.inc
+++ b/luggage_events.features.field_instance.inc
@@ -585,10 +585,12 @@ function luggage_events_field_default_field_instances() {
       'active' => 1,
       'module' => 'date',
       'settings' => array(
+        'display_all_day' => 1,
         'increment' => 1,
         'input_format' => 'j M Y - g:i:sa',
         'input_format_custom' => '',
         'label_position' => 'above',
+        'no_fieldset' => 0,
         'text_parts' => array(),
         'year_range' => '-3:+3',
       ),

--- a/luggage_events.info
+++ b/luggage_events.info
@@ -7,6 +7,7 @@ project = luggage_events
 dependencies[] = calendar
 dependencies[] = ctools
 dependencies[] = date
+dependencies[] = date_all_day
 dependencies[] = date_views
 dependencies[] = ds
 dependencies[] = features


### PR DESCRIPTION
Adds an all day checkbox with luggage_events.

To test:
- pull down this branch
- reset the luggage_event feature
- add an event. is there a checkbox for all day next to the when field?
- if you check this checkbox, are the events really all day? does the event view break?