### PR TITLE
DIGITALAG-47 Check to see if field is a location

### DIFF
--- a/luggage_events.module
+++ b/luggage_events.module
@@ -47,7 +47,7 @@ function luggage_events_element_info_alter(&$type) {
 }
 
 function luggage_events_field_process($element, $form_state, $complete_form) {
-  if (isset($complete_form['#bundle']) && $complete_form['#bundle'] == 'event') {
+  if (isset($complete_form['#bundle']) && $complete_form['#bundle'] == 'event' && $element['#field_name'] == 'field_event_location') {
     $element['title']['#description'] = t('Where is this event happening?');
     $element['url']['#description'] = t('Optional link to event location.');
   }


### PR DESCRIPTION
To test:
- add another link field to the event content type with help text
- check to make sure that the location title and help text are appearing on that field
- pull down these changes
- verify that the field's title and help text are correct