### PR TITLE
LUGG-1083 Override calendar template to fix duplicate ids

### DIFF
--- a/luggage_events.module
+++ b/luggage_events.module
@@ -32,6 +32,33 @@ function luggage_events_node_view($node, $view_mode, $langcode) {
   }
 }
 
+/**
+ * Implements hook_theme_registry_alter().
+ */
+function luggage_events_theme_registry_alter(&$theme_registry) {
+  // Defined path to the current module.
+  $module_path = drupal_get_path('module', 'luggage_events');
+  // Find all .tpl.php files in this module's folder recursively.
+  $template_file_objects = drupal_find_theme_templates($theme_registry, '.tpl.php', $module_path . '/templates');
+  // Iterate through all found template file objects.
+  foreach ($template_file_objects as $key => $template_file_object) {
+    // If the template has not already been overridden by a theme.
+    if (!isset($theme_registry[$key]['theme path']) || !preg_match('#/themes/#', $theme_registry[$key]['theme path'])) {
+      // Alter the theme path and template elements.
+      $theme_registry[$key]['theme path'] = $module_path;
+      $theme_registry[$key] = array_merge($theme_registry[$key], $template_file_object);
+      $theme_registry[$key]['type'] = 'module';
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function luggage_events_preprocess_calendar_mini(&$vars) {
+  $vars['month_id'] = $vars['id'];
+}
+
 /*
  * The link module helpfully tells you the maximum length limit of the title.
  * This is rather pointless and distracting. We zap this out.

--- a/templates/calendar-mini.tpl.php
+++ b/templates/calendar-mini.tpl.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @file
+ * Template to display a view as a mini calendar month.
+ *
+ * @see template_preprocess_calendar_mini.
+ *
+ * $day_names: An array of the day of week names for the table header.
+ * $rows: An array of data for each day of the week.
+ * $view: The view.
+ * $min_date_formatted: The minimum date for this calendar in the format YYYY-MM-DD HH:MM:SS.
+ * $max_date_formatted: The maximum date for this calendar in the format YYYY-MM-DD HH:MM:SS.
+ *
+ * $show_title: If the title should be displayed. Normally false since the title is incorporated
+ *   into the navigation, but sometimes needed, like in the year view of mini calendars.
+ *
+ */
+//dsm('Display: '. $display_type .': '. $min_date_formatted .' to '. $max_date_formatted);dsm($day_names);
+$params = array(
+  'view' => $view,
+  'granularity' => 'month',
+  'link' => FALSE,
+);
+?>
+<div class="calendar-calendar"><div class="month-view">
+    <?php if ($show_title): ?>
+      <div class="date-nav-wrapper clear-block">
+        <div class="date-nav">
+          <div class="date-heading">
+            <?php print theme('date_nav_title', $params) ?>
+          </div>
+        </div>
+      </div>
+    <?php endif; ?>
+    <table class="mini">
+      <thead>
+      <tr>
+        <?php foreach ($day_names as $cell): ?>
+          <th class="<?php print $cell['class']; ?>">
+            <?php print $cell['data']; ?>
+          </th>
+        <?php endforeach; ?>
+      </tr>
+      </thead>
+      <tbody>
+      <?php foreach ((array) $rows as $row): ?>
+        <tr>
+          <?php foreach ($row as $cell): ?>
+            <td id="<?php print $month_id . '-' . $cell['id']; ?>" class="<?php print $cell['class']; ?>">
+              <?php print $cell['data']; ?>
+            </td>
+          <?php endforeach; ?>
+        </tr>
+      <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div></div>


### PR DESCRIPTION
The calendar mini view for years is comprised of all twelve months as tables. Each day is a table cell with its date as an id attribute. The end and beginning of the months actually have hidden table cells for their corresponding dates from other months, which means that these dates have duplicate id attributes.

This pull request prefixes each day's id attribute with the number of the month of the calendar that it's located in. This means that dates that are technically part of the next month will have a prefix with the month they appear in, preventing duplicate id attributes.

To test:
- pull down this branch
- clear cache a bunch, might want to run `drush registry-rebuild`
- go to the year view of the events calendar
- inspect each date cell. The id attribute should look like `1-events-2018-1-1`. `-events-2018-1-1` is wrong and will occur if the preprocessor isn't written correctly.
- if you run the page through an accessibility checker, do you see errors about duplicate id attributes?