### PR TITLE
LUGG-1020 Add a space between minute and am/pm

### DIFF
--- a/luggage_events.install
+++ b/luggage_events.install
@@ -10,3 +10,13 @@ function luggage_events_enable() {
     ->condition('name', 'luggage_events')
     ->execute();
 }
+
+/**
+ * Add a space between the minute and am pm in the friendly date format
+ */
+function luggage_events_update_7103() {
+  $friendly_format = variable_get('date_format_friendly');
+  if ($friendly_format == 'l, F j, Y - g:ia') {
+    variable_set('date_format_friendly', 'l, F j, Y - g:i a');
+  }
+}

--- a/luggage_events.strongarm.inc
+++ b/luggage_events.strongarm.inc
@@ -21,7 +21,7 @@ function luggage_events_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'date_format_friendly';
-  $strongarm->value = 'l, F j, Y - g:ia';
+  $strongarm->value = 'l, F j, Y - g:i a';
   $export['date_format_friendly'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
To test:
- Pull down a Luggage site. Checkout this branch and [`LUGG-1020-2`](https://github.com/isubit/luggage_contrib/tree/LUGG-1020-2) on the luggage_contrib module. Run `drush updb -y` (you might have to install the `module_filter` module to do this)
- Look at luggage_events. Did the friendly date format get updated?
- Also, create a fresh luggage site using this branch and [`LUGG-1020-2`](https://github.com/isubit/luggage_contrib/tree/LUGG-1020-2) on the luggage_contrib module. Did the friendly date format get created correctly?