### PR TITLE
LUGG-1096 Add settings for alternate_url to front page view

### DIFF
--- a/luggage_events.views_default.inc
+++ b/luggage_events.views_default.inc
@@ -718,6 +718,53 @@ function luggage_events_views_default_views() {
   $handler->display->display_options['defaults']['row_plugin'] = FALSE;
   $handler->display->display_options['row_plugin'] = 'fields';
   $handler->display->display_options['defaults']['row_options'] = FALSE;
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Path */
+  $handler->display->display_options['fields']['path']['id'] = 'path';
+  $handler->display->display_options['fields']['path']['table'] = 'node';
+  $handler->display->display_options['fields']['path']['field'] = 'path';
+  $handler->display->display_options['fields']['path']['label'] = '';
+  $handler->display->display_options['fields']['path']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['path']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['path']['absolute'] = TRUE;
+  /* Field: Content: Alternate URL */
+  $handler->display->display_options['fields']['field_event_alternate_url']['id'] = 'field_event_alternate_url';
+  $handler->display->display_options['fields']['field_event_alternate_url']['table'] = 'field_data_field_event_alternate_url';
+  $handler->display->display_options['fields']['field_event_alternate_url']['field'] = 'field_event_alternate_url';
+  $handler->display->display_options['fields']['field_event_alternate_url']['label'] = '';
+  $handler->display->display_options['fields']['field_event_alternate_url']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_event_alternate_url']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_event_alternate_url']['empty'] = '[path]';
+  $handler->display->display_options['fields']['field_event_alternate_url']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_event_alternate_url']['type'] = 'link_url';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['make_link'] = TRUE;
+  $handler->display->display_options['fields']['title']['alter']['path'] = '[field_event_alternate_url]';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['title']['hide_alter_empty'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: When */
+  $handler->display->display_options['fields']['field_event_when']['id'] = 'field_event_when';
+  $handler->display->display_options['fields']['field_event_when']['table'] = 'field_data_field_event_when';
+  $handler->display->display_options['fields']['field_event_when']['field'] = 'field_event_when';
+  $handler->display->display_options['fields']['field_event_when']['label'] = '';
+  $handler->display->display_options['fields']['field_event_when']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_event_when']['hide_alter_empty'] = FALSE;
+  $handler->display->display_options['fields']['field_event_when']['settings'] = array(
+    'format_type' => 'friendly',
+    'fromto' => 'both',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  $handler->display->display_options['fields']['field_event_when']['group_rows'] = FALSE;
+  $handler->display->display_options['fields']['field_event_when']['delta_offset'] = '0';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */


### PR DESCRIPTION
This adds alternate url settings to the front page block view in luggage_events.

To test:
- Pull down this branch on a fresh copy of luggage
- Run `drush fra -y` and clear caches
- Add an event with an alternate URL. If you go to the front page, does the event block link to the alternate URL instead of the node?